### PR TITLE
Add vt.instructure.com to domain matching

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "manifest_version": 2,
     "content_scripts": [
         {
-            "matches": ["https://canvas.vt.edu/"],
+            "matches": ["https://canvas.vt.edu/", "https://vt.instructure.com/"],
             "js": ["block.js"]
         }
     ],


### PR DESCRIPTION
https://vt.instructure.com is also a valid domain for reaching Canvas, added it into the manifest. Tested on my machine.